### PR TITLE
Add PHP 8.4 and 8.5 support and update CI workflow

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-latest ]
-        php: [ '7.4', '8.0', '8.1', '8.2', '8.3']
+        php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
     name: PHP ${{ matrix.php }}
 
     steps:
@@ -23,7 +23,7 @@ jobs:
       run: composer validate
 
     - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-suggest
+      run: composer install --prefer-dist --no-progress
 
     - name: Run Snyk to check for vulnerabilities
       uses: snyk/actions/php@master

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Optimized for large datasets. Suitable for keeping in sync internal data with ou
 
 # Compatibility
 
-* PHP 7.4, 8.0, 8.1, 8.2, 8.3
+* PHP 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5
 
 # Installations
 


### PR DESCRIPTION
## Summary
This PR extends PHP version support to include PHP 8.4 and 8.5, and updates the CI/CD workflow to test against these new versions.

## Key Changes
- **CI/CD Updates**: Extended the GitHub Actions PHP test matrix to include PHP 8.4 and 8.5 alongside existing versions (7.4, 8.0, 8.1, 8.2, 8.3)
- **Composer Configuration**: Removed the deprecated `--no-suggest` flag from the `composer install` command, which is no longer supported in recent Composer versions
- **Documentation**: Updated README.md to reflect support for PHP 8.4 and 8.5

## Implementation Details
- The test matrix now covers a broader range of PHP versions to ensure compatibility with the latest releases
- The `--no-suggest` flag removal aligns with modern Composer best practices and improves CI/CD compatibility

https://claude.ai/code/session_011pzsvmoNcT6Z8JByQYqUUb